### PR TITLE
Read mint addresses as a json file instead of text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
+token-mint-addresses.json
+
+## Build output folders
+**/build/*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/1_record_holders/src/main.ts
+++ b/1_record_holders/src/main.ts
@@ -1,6 +1,5 @@
 import { Connection, PublicKey } from "@solana/web3.js";
-import { createInterface } from "readline";
-import { createReadStream } from "fs";
+import { readFileSync } from "fs";
 import { program } from "commander";
 import pRetry from "p-retry";
 
@@ -9,12 +8,12 @@ program
   .option(
     "-t, --token-address-log <string>",
     "token accounts",
-    "../token-mint-addresses.log"
+    "../token-mint-addresses.json"
   )
   .option(
     "-e, --rpc-host <string>",
     "rpc host",
-    "https://mainnet-beta.api.solana.com"
+    "https://api.mainnet-beta.solana.com"
   )
   .option(
     "-c, --chill <number>",
@@ -47,13 +46,11 @@ async function mineCurrentHolder(
 }
 
 async function main() {
-  const lineReader = createInterface({
-    input: createReadStream(tokenAddressLog),
-    crlfDelay: Infinity,
-  });
+  const mintList = JSON.parse(
+    readFileSync(tokenAddressLog, 'utf8')
+  ) as Array<string>;
 
-  for await (const line of lineReader) {
-    const tokenAccount = line.split(" ").pop()!;
+  for await (const tokenAccount of mintList) {
     const currentHolder = await pRetry(
       async () => await mineCurrentHolder(tokenAccount),
       {


### PR DESCRIPTION
tools like the one mentioned in the documentation output the list of
mints in a json format. Having this read the json instead of a log file
format eliminates a step of converting the json file into the log
format.